### PR TITLE
Preserve original filename when downloading

### DIFF
--- a/controllers/GetController.php
+++ b/controllers/GetController.php
@@ -16,6 +16,8 @@ class GetController extends BaseController {
 		header('Content-type: ' . $contentType);
 		$contentLength = filesize($filePath);
 		header('Content-length: ' . $contentLength);
+		$downloadName = basename($media->getFilename());
+		header("Content-Disposition: inline; filename=\"$downloadName\"");
 
 		// Cleanup the output buffer so that readfile doesn't fail by OOM
 		while (ob_get_level()) {


### PR DESCRIPTION
Preserve the original file when downloading (instead of downloading as download.jpg).
